### PR TITLE
Move variant notation docs from parser repo to here

### DIFF
--- a/docs/variant_notation/continuous.md
+++ b/docs/variant_notation/continuous.md
@@ -1,0 +1,114 @@
+
+# Continuous Notation
+
+All continuous notation follows a similar pattern that is loosely defined as:
+
+```text
+<feature>:<prefix>.<pos><type><seq>
+```
+
+The `reference feature` would be the gene (chromosome, transcript, etc.)  name that the variant
+occurs on. The prefix denotes the coordinate type (see [prefixes](#prefixes)). The range is the
+position or positions of the variant. For a deletion, this is the range that is deleted. For an
+insertion, this is the two positions the sequence is inserted between. The sequence element will
+depend on the type of variant being described, but often this is the untemplated/inserted sequence.
+
+The sequence element is often optional. For all notation types there are general and more specific
+versions of notating the same event. Where possible more specificity is preferred. But it is
+recognized that notation coming from outside sources may not always provide all information. For
+each variant, the different equivalent notation options are shown below in order of increasing
+specificity.
+
+## Examples
+
+### Substitution
+
+[Genomic/CDS substitution variants](http://varnomen.hgvs.org/recommendations/DNA/variant/substitution/)
+differ from
+[protein substitution variants](http://varnomen.hgvs.org/recommendations/protein/variant/substitution/).
+Therefore examples of both will be given.
+
+A protein missense mutation where G is replaced with D
+
+```text
+KRAS:p.G12D
+```
+
+A genomic substitution from A to C
+
+```text
+chr11:g.1234A>C
+```
+
+### Indel
+
+A [protein deletion](http://varnomen.hgvs.org/recommendations/protein/variant/deletion/) of amino
+acids GH and insertion of three amino acids TTA
+
+```text
+EGFR:p.G512_H513delins
+EGFR:p.G512_H513delins3
+EGFR:p.G512_H513delGHins
+EGFR:p.G512_H513delGHins3
+EGFR:p.G512_H513delinsTTA
+EGFR:p.G512_H513delGHinsTTA
+```
+
+#### Insertion
+
+Insertions must be a range to specify between which two coordinates the insertion occurs. This
+avoids the problem
+when only a single coordinate is given of which side it is inserted on.
+
+An [protein insertion](http://varnomen.hgvs.org/recommendations/protein/variant/insertion/) of four
+amino acids between G123 and H124. The sequence element here is optional and can also be described
+as a number if the number of bases inserted is known but the sequence is not given.
+
+```text
+EGFR:p.G123_H124ins
+EGFR:p.G123_H124ins4
+EGFR:p.G123_H124insCCST
+```
+
+### Deletion
+
+The reference sequence is optional when denoting a deletion. For example the same deletion could
+be notated both ways as shown below.
+
+```text
+EGFR:p.R10_G14del
+EGFR:p.R10_G14del5
+EGFR:p.R10_G14delRSTGG
+```
+
+If the reference sequence is known, it is always better to provide more information than less.
+
+#### Duplication
+
+Four amino acids are duplicated. Once again, the sequence element is optional
+
+```text
+EGFR:p.R10_G14dup
+EGFR:p.R10_G14dup5
+EGFR:p.R10_G14dupRSTGG
+```
+
+### Frameshift
+
+[Frameshifts](http://varnomen.hgvs.org/recommendations/protein/variant/frameshift/) are only
+applicable to variants denoted with protein coordinates. Frameshift notation follows the pattern
+below
+
+```text
+<feature>:p.<pos><first alternate AA>fs*<position of next truncating AA>
+```
+
+The `first alternate AA`, and `position of next truncating AA` are both optional elements. For
+example the protein frameshift variant might be noted multiple ways
+
+```text
+PTEN:p.G123fs
+PTEN:p.G123fs*10
+PTEN:p.G123Afs
+PTEN:p.G123Afs*10
+```

--- a/docs/variant_notation/coordinate_systems/cytoband.md
+++ b/docs/variant_notation/coordinate_systems/cytoband.md
@@ -1,0 +1,19 @@
+# CytoBand Coordinates
+
+CytoBand notation is included in GraphKB-HGVS to increase compatibility with variant notation in older publications and knowledgebases.
+
+CytoBand coordinates (`y`) are not a feature of HGVS, however variants using this system follow much the same patterns as the other types. Since this coordinate system is not very specific, the types of variants one can describe is more limited. Generally only duplications/gains, deletions/losses, inversions, and translocations can be described. Additionally sequence is never included. Any position in the CytoBand coordinate system is described by the pattern
+
+```text
+<arm><majorBand>.<minorBand>
+```
+
+The minor band number is optional.
+
+## Deletion Example
+
+A deletion spanning p11.1 to p12.
+
+```text
+chr1:y.p11.1_p12del
+```

--- a/docs/variant_notation/coordinate_systems/index.md
+++ b/docs/variant_notation/coordinate_systems/index.md
@@ -1,0 +1,15 @@
+# About
+
+Notation forms will use a common prefix notation. These describe the units of any positions given
+in the variant description. For example, protein notation (`p.`) would have amino acids as units.
+
+| Prefix | Coordinate Type                     |                           Standard HGVS                            |
+| :----: | ----------------------------------- | :----------------------------------------------------------------: |
+|   g    | Genomic                             |   [&#10004;](https://varnomen.hgvs.org/bg-material/refseq/#DNAg)   |
+|   c    | Coding reference sequence (CDS)     |   [&#10004;](https://varnomen.hgvs.org/bg-material/refseq/#DNAc)   |
+|   p    | Protein                             | [&#10004;](https://varnomen.hgvs.org/bg-material/refseq/#proteinp) |
+|   e    | Exon                                |                                                                    |
+|   y    | [CytoBand/Cytogenic](./cytoband.md) |                                                                    |
+|   i    | Intronic position                   |                                                                    |
+|   r    | RNA position                        |   [&#10004;](https://varnomen.hgvs.org/bg-material/refseq/#RNAr)   |
+|   n    | non-coding DNA reference sequence   |   [&#10004;](https://varnomen.hgvs.org/bg-material/refseq/#DNAn)   |

--- a/docs/variant_notation/index.md
+++ b/docs/variant_notation/index.md
@@ -1,0 +1,45 @@
+# About
+
+The variant notation is a shorthand to make it faster to enter/display variants. It is made up of two forms: [continuous](./continuous.md), and [multi-feature](./split.md). Most people will be more familiar with the continuous notation. It is based on [HGVS v15.11](http://varnomen.hgvs.org/) and can be used to describe any variant that has only a single reference feature (i.e. KRAS). [Multi-feature notation](./split.md) is required when one needs to describe any variant involving multiple reference features. This could be something like a gene fusion where the reference features might be EWSR1, and FLI1.
+
+!!! Warning
+
+    The notation examples included in this documentation do not necessarily represent actual mutations. While they are all valid syntax, no attempt has been made to check that the sequences given are correct
+
+## General Notation
+
+### Prefixes
+
+Both forms of notation can be described as two breakpoints and an event type. Some may also include reference sequence and untemplated sequence descriptions. Additionally both forms will use a common prefix notation. These prefixes are described under [coordinate systems](./coordinate_systems/index.md)
+
+### Variant Types
+
+The expected variant types are given below. Some types are only applicable to certain coordinate systems (i.e. frameshifts are protein only).
+
+| Variant Type | Description            |                                   Standard HGVS                                   | Prefix Specific |
+| ------------ | ---------------------- | :-------------------------------------------------------------------------------: | :-------------: |
+| >            | substitutions          |  [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/substitution/)  |  g / c / r / n  |
+| del          | deletions              |    [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/deletion/)    |                 |
+| delins       | indels                 |     [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/delins/)     |                 |
+| dup          | duplications           |  [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/duplication/)   |                 |
+| fs           | frameshifts            | [&#10004;](https://varnomen.hgvs.org/recommendations/protein/variant/frameshift/) |        p        |
+| ext          | extensions             | [&#10004;](https://varnomen.hgvs.org/recommendations/protein/variant/extension/)  |        p        |
+| ins          | insertions             |   [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/insertion/)    |                 |
+| inv          | inversions             |   [&#10004;](https://varnomen.hgvs.org/recommendations/DNA/variant/inversion/)    |                 |
+| fusion       | gene fusion            |                                                                                   |                 |
+| trans        | translocation          |                                                                                   |                 |
+| itrans       | inverted translocation |                                                                                   |                 |
+| mut          | non-specific mutation  |                                                                                   |                 |
+| spl          | splice site mutation   |                                                                                   |        p        |
+| mis          | missense mutation      |                                                                                   |        p        |
+
+### Unsupported HGVS Features
+
+There are a few elements of the [HGVS v15.11](http://varnomen.hgvs.org/) notation that are not yet supported ([contributions are welcome!](https://github.com/bcgsc/pori_graphkb_parser)). These include:
+
+- [mosacism](http://varnomen.hgvs.org/recommendations/DNA/variant/complex/)
+- [chimerism](http://varnomen.hgvs.org/recommendations/DNA/variant/complex/)
+- [RNA variants](http://varnomen.hgvs.org/recommendations/RNA/)
+- [conversions](http://varnomen.hgvs.org/recommendations/DNA/variant/conversion/)
+- [alleles](http://varnomen.hgvs.org/recommendations/DNA/variant/alleles/)
+- [v20 Complex Variants](https://varnomen.hgvs.org/recommendations/DNA/variant/complex/)

--- a/docs/variant_notation/split.md
+++ b/docs/variant_notation/split.md
@@ -1,0 +1,52 @@
+
+# Multi-Feature (Split) Notation
+
+Multi-feature notation is a novel feature of GraphKB-HGVS and not part of standard HGVS. It is
+based on the original form for cytogenetic descriptions of translocations (as previously
+reccommended by HGVS) but this form is generalized to allow other coordinate systems.
+
+Multi-Feature notation will use the same positions and coordinate systems as continuous notation.
+However parentheses are used to divide features and positions. All multi-feature variants should
+following the pattern below
+
+```text
+(<feature>,<feature>):<type>(<prefix>.<pos>,<prefix>.<pos>)<seq>
+```
+
+Untemplated sequence should only be included for sequence specific coordinate types such as
+genomic, CDS, and protein. Where possible, continuous notation is preferred to multi-feature.
+
+## Examples
+
+### Gene Fusion
+
+Using exon coordinates we could describe a gene fusion of exon 4 of EWSR1 to exon 7 of FLI1 as
+follows
+
+```text
+(EWSR1,FLI1):fusion(e.4,e.7)
+```
+
+A range can also be used here. When a range of positions is given it indicates uncertainty. Since
+the range is already separated by a comma it is not necessary to enclose the uncertainty in
+parentheses (as you would for continuous notation).
+
+For example, if we wanted to express a fusion of any exon from 4-6 of EWSR1 to any exon from 7-10
+of FLI1
+
+```text
+(ESWR1,FLI1):fusion(e.4_6,e.7_10)
+```
+
+### Genomic Translocation
+
+Multi-feature variants can also be described using the genomic coordinate system (`g`). For example
+a translocation might be described
+
+```text
+(chr8,chr7):trans(g.1234,g.4567)
+(chr8,chr7):trans(g.1234,g.4567)AAT
+```
+
+Above we are describing a translocation from chr8:1234 to chr7:4567 where AAT is the untemplated
+sequence inserted between the breakpoints.


### PR DESCRIPTION
- Moves the docs that were grouped with the parser to the main repo (this one) since this notation is used throughout PORI and the parser does not have a docs site